### PR TITLE
店側と客側での機能分離

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -25,13 +25,13 @@ class ReservationsController < ApplicationController
   end
 
   def cancel
-    reservation = current_user.reservations.find(params[:reservation_id])
+    reservation = current_user.reservations.find(params[:id])
     reservation.cancel!
     redirect_to root_url, notice: "#{reservation.shop.name}の予約をキャンセルしました"
   end
 
   def enter
-    reservation = Reservation.find(params[:reservation_id])
+    reservation = Reservation.find(params[:id])
     reservation.enter!
     redirect_to shop_path(reservation.shop), notice: "#{reservation.user.name}が入店しました"
   end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -4,13 +4,16 @@ class ReservationsController < ApplicationController
   def new
     @shop = Shop.find(params[:shop_id])
     reservation = current_user.reservations.find_by(shop_id: params[:shop_id])
-    if reservation
+    #未予約か予約をキャンセルした場合のみ、予約できるようにする
+    if reservation && !(reservation.cancel?)
       redirect_to shop_reservation_path(@shop, reservation)
     end
     @reservation = Reservation.new
   end
 
   def show
+    @shop = Shop.find(params[:shop_id])
+    @reservation = current_user.reservations.find(params[:id])
   end
 
   def create
@@ -19,6 +22,12 @@ class ReservationsController < ApplicationController
     reservation.reserve(shop)
     reservation.save!
     redirect_to root_url, notice: "#{shop.name}の予約を#{reservation.reserve_on.to_s(:ja)}で予約をお取りしました"
+  end
+
+  def cancel
+    reservation = current_user.reservations.find(params[:reservation_id])
+    reservation.cancel!
+    redirect_to root_url, notice: "#{reservation.shop.name}の予約をキャンセルしました"
   end
 
   private

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -30,10 +30,19 @@ class ReservationsController < ApplicationController
     redirect_to root_url, notice: "#{reservation.shop.name}の予約をキャンセルしました"
   end
 
+  def enter
+    reservation = Reservation.find(params[:reservation_id])
+    reservation.enter!
+    redirect_to shop_path(reservation.shop), notice: "#{reservation.user.name}が入店しました"
+  end
+
   private
 
   def reservation_params
     params.require(:reservation).permit(:people_number)
+  end
+
+  def correct_user
   end
 
   def different_user

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -47,11 +47,6 @@ class ShopsController < ApplicationController
 
   private
 
-  def match_user
-    unless current_user.shops.find_by(id: params[:id])
-    end
-  end
-
   def shop_params
     params.require(:shop).permit(:name, :place, :wait_time)
   end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,5 +1,5 @@
 class ShopsController < ApplicationController
-  before_action :set_shop, only: [:edit, :update, :destroy]
+  before_action :set_shop, only: [:edit, :update]
   before_action :shop_owner?, only: [:show, :entered, :canceled]
 
   def index
@@ -45,8 +45,15 @@ class ShopsController < ApplicationController
   end
 
   def destroy
+    shop = current_user.shops.find(params[:id])
     shop.destroy
     redirect_to shops_url, notice: "#{shop.name}を削除しました"
+  end
+
+  def reset
+    shop = current_user.shops.find(params[:id])
+    shop.delete_all_reservation
+    redirect_to shop_url(shop), notice: "#{shop.name}の予約状況をリセットしました"
   end
 
   private

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,6 +1,10 @@
 class ShopsController < ApplicationController
   def index
-    @shops = Shop.all
+    @shops = Shop.where.not(user_id: current_user.id)
+  end
+
+  def my_index
+    @shops = Shop.where(user_id: current_user.id)
   end
 
   def show

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,4 +1,6 @@
 class ShopsController < ApplicationController
+  before_action :set_shop, only: [:edit, :update, :destroy]
+
   def index
     @shops = Shop.where.not(user_id: current_user.id)
   end
@@ -31,11 +33,9 @@ class ShopsController < ApplicationController
   end
 
   def edit
-    @shop = current_user.shops.find(params[:id])
   end
 
   def update
-    @shop = current_user.shops.find(params[:id])
     if @shop.update(shop_params)
       redirect_to shop_url(@shop), notice: "#{@shop.name}を更新しました"
     else
@@ -44,12 +44,15 @@ class ShopsController < ApplicationController
   end
 
   def destroy
-    @shop = current_user.shops.find(params[:id])
     shop.destroy
     redirect_to shops_url, notice: "#{shop.name}を削除しました"
   end
 
   private
+
+  def set_shop
+    @shop = current_user.shops.find(params[:id])
+  end
 
   def shop_params
     params.require(:shop).permit(:name, :place, :wait_time)

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -18,6 +18,24 @@ class ShopsController < ApplicationController
     end
   end
 
+  def entered
+    @shop = Shop.find(params[:id])
+    unless current_user.shops.find_by(id: params[:id])
+      redirect_to new_shop_reservation_path(@shop)
+    else
+      @reservations = @shop.reservations.all
+    end
+  end
+
+  def canceled
+    @shop = Shop.find(params[:id])
+    unless current_user.shops.find_by(id: params[:id])
+      redirect_to new_shop_reservation_path(@shop)
+    else
+      @reservations = @shop.reservations.all
+    end
+  end
+
   def new
     @shop = Shop.new
     @reservation = Reservation.new

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,5 +1,6 @@
 class ShopsController < ApplicationController
   before_action :set_shop, only: [:edit, :update, :destroy]
+  before_action :shop_owner?, only: [:show, :entered, :canceled]
 
   def index
     @shops = Shop.where.not(user_id: current_user.id)
@@ -10,30 +11,12 @@ class ShopsController < ApplicationController
   end
 
   def show
-    @shop = Shop.find(params[:id])
-    unless current_user.shops.find_by(id: params[:id])
-      redirect_to new_shop_reservation_path(@shop)
-    else
-      @reservations = @shop.reservations.all
-    end
   end
 
   def entered
-    @shop = Shop.find(params[:id])
-    unless current_user.shops.find_by(id: params[:id])
-      redirect_to new_shop_reservation_path(@shop)
-    else
-      @reservations = @shop.reservations.all
-    end
   end
 
   def canceled
-    @shop = Shop.find(params[:id])
-    unless current_user.shops.find_by(id: params[:id])
-      redirect_to new_shop_reservation_path(@shop)
-    else
-      @reservations = @shop.reservations.all
-    end
   end
 
   def new
@@ -70,6 +53,15 @@ class ShopsController < ApplicationController
 
   def set_shop
     @shop = current_user.shops.find(params[:id])
+  end
+
+  def shop_owner?
+    @shop = Shop.find(params[:id])
+    unless current_user.shops.find_by(id: params[:id])
+      redirect_to new_shop_reservation_path(@shop)
+    else
+      @reservations = @shop.reservations.all
+    end
   end
 
   def shop_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,12 @@
 class UsersController < ApplicationController
   skip_before_action :login_required
+  before_action :set_user, only: [:edit, :update, :destroy]
 
   def new
     @user = User.new
   end
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def create
@@ -20,8 +20,6 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(params[:id])
-
     if @user.update(user_params)
       redirect_to admin_user_path(@user), notice: "ユーザー「#{@user.name}」を更新しました。"
     else
@@ -30,12 +28,15 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:id])
     @user.destroy
     redirect_to admin_users_url, notice: "ユーザー「#{@user.name}を削除しました。」"
   end
 
   private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :login_required
+  before_action :correct_user, only: [:edit, :update, :destroy]
   before_action :set_user, only: [:edit, :update, :destroy]
 
   def new
@@ -36,6 +37,12 @@ class UsersController < ApplicationController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def correct_user
+    unless current_user == User.find(params[:id])
+      redirect_to root_url
+    end
   end
 
   def user_params

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -3,13 +3,22 @@ class Shop < ApplicationRecord
   validates :wait_time, presence: true
 
   belongs_to :user
-  has_many :reservations
+  has_many :reservations, dependent: :destroy
 
   def set_expected
     DateTime.now + Rational(wait_time, 24 * 60)
   end
 
+  def total_people_number
+    n = 0
+    reservations.yet.each do |reservation|
+      n += reservation.people_number
+    end
+    n
+  end
+
   def delete_all_reservation
     reservations.destroy_all
   end
+
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -8,4 +8,8 @@ class Shop < ApplicationRecord
   def set_expected
     DateTime.now + Rational(wait_time, 24 * 60)
   end
+
+  def delete_all_reservation
+    reservations.destroy_all
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
 
-  has_many :shops
-  has_many :reservations
+  has_many :shops, dependent: :destroy
+  has_many :reservations, dependent: :destroy
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,7 +13,8 @@ html
 
       ul.navbar-nav.ml-auto
         - if current_user
-          li.nav-item= link_to 'お店一覧', shops_path, class: 'nav-link'    
+          li.nav-item= link_to '予約する', shops_path, class: 'nav-link'
+          li.nav-item= link_to '自分のお店一覧', my_index_shops_path, class: 'nav-link'      
           li.nav-item= link_to 'ログアウト', logout_path, method: :delete , class: 'nav-link'
         - else    
           li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'  

--- a/app/views/reservations/_wait_number.html.slim
+++ b/app/views/reservations/_wait_number.html.slim
@@ -1,0 +1,5 @@
+h3
+  = shop.reservations.yet.count
+  | 組
+  = shop.total_people_number
+  | 人待ち

--- a/app/views/reservations/new.html.slim
+++ b/app/views/reservations/new.html.slim
@@ -1,6 +1,12 @@
+h3 
+  | 今予約すると予約時間は
+  strong = @shop.set_expected.to_s(:ja)
+  | です
+  
+
 = form_with model: @reservation, url: [@shop, @reservation], local: true do |f|
   .form-group
     = f.label :people_number, '人数'
     br
     = f.select :people_number, [["1",1],["2",2],["3",3],["4",4],["5",5],["6",6],["7",7],["8",8]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
-  = f.submit '予約する', class: 'btn btn-primary'
+  = f.submit '予約する', data: { confirm: "#{@shop.set_expected.to_s(:ja)}で予約をお取りします。よろしいですか?"}, class: 'btn btn-primary'

--- a/app/views/reservations/new.html.slim
+++ b/app/views/reservations/new.html.slim
@@ -1,9 +1,10 @@
+= render partial: 'wait_number', locals: { shop: @shop }
+
 h3 
   | 今予約すると予約時間は
   strong = @shop.set_expected.to_s(:ja)
   | です
   
-
 = form_with model: @reservation, url: [@shop, @reservation], local: true do |f|
   .form-group
     = f.label :people_number, '人数'

--- a/app/views/reservations/show.html.slim
+++ b/app/views/reservations/show.html.slim
@@ -1,3 +1,3 @@
 h1 test
 
-= link_to '予約のキャンセル', shop_reservation_cancel_path(@shop, @reservation), method: :patch, data: { confirm: "#{@shop.name}の予約をキャンセルします。よろしいですか。" }, class: 'btn btn-danger mr-3'
+= link_to '予約のキャンセル', cancel_shop_reservation_path(@shop, @reservation), method: :patch, data: { confirm: "#{@shop.name}の予約をキャンセルします。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/reservations/show.html.slim
+++ b/app/views/reservations/show.html.slim
@@ -1,2 +1,3 @@
 h1 test
 
+= link_to '予約のキャンセル', shop_reservation_cancel_path(@shop, @reservation), method: :patch, data: { confirm: "#{@shop.name}の予約をキャンセルします。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/reservations/show.html.slim
+++ b/app/views/reservations/show.html.slim
@@ -1,3 +1,3 @@
-h1 test
+= render partial: 'wait_number', locals: { shop: @shop }
 
 = link_to '予約のキャンセル', cancel_shop_reservation_path(@shop, @reservation), method: :patch, data: { confirm: "#{@shop.name}の予約をキャンセルします。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/_link.html.slim
+++ b/app/views/shops/_link.html.slim
@@ -1,0 +1,2 @@
+= link_to '詳細情報の編集', edit_shop_path(shop), class: 'btn btn-success mr-3'
+= link_to 'お店の削除', shop, method: :delete, data: { confirm: "#{shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/_management.html.slim
+++ b/app/views/shops/_management.html.slim
@@ -1,0 +1,40 @@
+h1= shop.name
+
+br
+
+strong
+  | 設定予約時間：
+  = shop.set_expected.to_s(:ja)
+
+table.table.table-hover
+  tbody
+    tr
+      th= Shop.human_attribute_name(:place)
+      td= shop.place
+
+= form_with model: shop, local: true do |f|
+  .form-group
+    = f.label :wait_time
+    br
+    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
+  = f.submit nil, class: 'btn btn-primary'
+
+br
+
+.col-xs-8
+  ul.nav.nav-tabs
+    li.nav-item
+      = link_to shop_path(shop), class: "nav-link #{'active' if current_page?(shop_path(shop))}" do
+        | 未入店
+        span.badge.badge-primary
+          = shop.reservations.yet.count
+    li.nav-item
+      = link_to entered_shop_path(shop), class: "nav-link #{'active' if current_page?(entered_shop_path(shop))}" do
+        | 入店済み
+        span.badge.badge-dark
+          = shop.reservations.enter.count
+    li.nav-item
+      = link_to canceled_shop_path(shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(shop))}" do
+        | キャンセル
+        span.badge.badge-danger
+          = shop.reservations.cancel.count

--- a/app/views/shops/_management.html.slim
+++ b/app/views/shops/_management.html.slim
@@ -2,6 +2,10 @@ h1= shop.name
 
 br
 
+= link_to 'リセット', reset_shop_path(shop), method: :delete, data: { confirm: "#{shop.name}の予約状況をリセットします。よろしいですか？" }, class: 'btn btn-danger mr-3'
+
+br
+
 strong
   | 設定予約時間：
   = shop.set_expected.to_s(:ja)

--- a/app/views/shops/_management.html.slim
+++ b/app/views/shops/_management.html.slim
@@ -2,6 +2,14 @@ h1= shop.name
 
 br
 
+h3
+  = shop.reservations.yet.count
+  | 組
+  = shop.total_people_number
+  | 人待ち
+
+br
+
 = link_to 'リセット', reset_shop_path(shop), method: :delete, data: { confirm: "#{shop.name}の予約状況をリセットします。よろしいですか？" }, class: 'btn btn-danger mr-3'
 
 br

--- a/app/views/shops/_table.html.slim
+++ b/app/views/shops/_table.html.slim
@@ -1,0 +1,14 @@
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Shop.human_attribute_name(:name)
+      th= Shop.human_attribute_name(:place)
+      th= Shop.human_attribute_name(:wait_time)
+    tbody
+      - shops.each do |shop|
+        tr
+          td= link_to shop.name, shop
+          td= shop.place
+          td
+            = shop.wait_time

--- a/app/views/shops/canceled.html.slim
+++ b/app/views/shops/canceled.html.slim
@@ -1,0 +1,62 @@
+h1= @shop.name
+
+br
+
+strong
+  | 設定予約時間：
+  = @shop.set_expected.to_s(:ja)
+
+table.table.table-hover
+  tbody
+    tr
+      th= Shop.human_attribute_name(:place)
+      td= @shop.place
+
+= form_with model: @shop, local: true do |f|
+  .form-group
+    = f.label :wait_time
+    br
+    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
+  = f.submit nil, class: 'btn btn-primary'
+
+br
+
+.col-xs-8
+  ul.nav.nav-tabs
+    li.nav-item
+      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
+        | 未入店
+        span.badge.badge-primary
+          = @shop.reservations.yet.count
+    li.nav-item
+      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
+        | 入店済み
+        span.badge.badge-dark
+          = @shop.reservations.enter.count
+    li.nav-item
+      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
+        | キャンセル
+        span.badge.badge-danger
+          = @shop.reservations.cancel.count
+    
+  table.table.table-hover
+    thead.thead-default
+      tr
+        th= Reservation.human_attribute_name(:reserve_on)
+        th= User.human_attribute_name(:name)
+        th= Reservation.human_attribute_name(:people_number)
+        th= Reservation.human_attribute_name(:status)
+        th
+      tbody
+        - @reservations.cancel.each do |reservation|
+          tr
+            td= reservation.reserve_on.to_s(:ja)
+            td= reservation.user.name
+            td= reservation.people_number
+            td= reservation.status_i18n
+            td
+              - if reservation.yet?
+                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
+
+  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
+  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/canceled.html.slim
+++ b/app/views/shops/canceled.html.slim
@@ -1,62 +1,16 @@
-h1= @shop.name
-
-br
-
-strong
-  | 設定予約時間：
-  = @shop.set_expected.to_s(:ja)
-
-table.table.table-hover
-  tbody
-    tr
-      th= Shop.human_attribute_name(:place)
-      td= @shop.place
-
-= form_with model: @shop, local: true do |f|
-  .form-group
-    = f.label :wait_time
-    br
-    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
-  = f.submit nil, class: 'btn btn-primary'
-
-br
-
-.col-xs-8
-  ul.nav.nav-tabs
-    li.nav-item
-      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
-        | 未入店
-        span.badge.badge-primary
-          = @shop.reservations.yet.count
-    li.nav-item
-      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
-        | 入店済み
-        span.badge.badge-dark
-          = @shop.reservations.enter.count
-    li.nav-item
-      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
-        | キャンセル
-        span.badge.badge-danger
-          = @shop.reservations.cancel.count
+= render partial: 'management', locals: { shop: @shop }
     
-  table.table.table-hover
-    thead.thead-default
-      tr
-        th= Reservation.human_attribute_name(:reserve_on)
-        th= User.human_attribute_name(:name)
-        th= Reservation.human_attribute_name(:people_number)
-        th= Reservation.human_attribute_name(:status)
-        th
-      tbody
-        - @reservations.cancel.each do |reservation|
-          tr
-            td= reservation.reserve_on.to_s(:ja)
-            td= reservation.user.name
-            td= reservation.people_number
-            td= reservation.status_i18n
-            td
-              - if reservation.yet?
-                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Reservation.human_attribute_name(:reserve_on)
+      th= User.human_attribute_name(:name)
+      th= Reservation.human_attribute_name(:people_number)
+    tbody
+      - @reservations.cancel.each do |reservation|
+        tr
+          td= reservation.reserve_on.to_s(:ja)
+          td= reservation.user.name
+          td= reservation.people_number
 
-  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
-  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'
+= render partial: 'link', locals: { shop: @shop }

--- a/app/views/shops/entered.html.slim
+++ b/app/views/shops/entered.html.slim
@@ -1,0 +1,62 @@
+h1= @shop.name
+
+br
+
+strong
+  | 設定予約時間：
+  = @shop.set_expected.to_s(:ja)
+
+table.table.table-hover
+  tbody
+    tr
+      th= Shop.human_attribute_name(:place)
+      td= @shop.place
+
+= form_with model: @shop, local: true do |f|
+  .form-group
+    = f.label :wait_time
+    br
+    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
+  = f.submit nil, class: 'btn btn-primary'
+
+br
+
+.col-xs-8
+  ul.nav.nav-tabs
+    li.nav-item
+      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
+        | 未入店
+        span.badge.badge-primary
+          = @shop.reservations.yet.count
+    li.nav-item
+      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
+        | 入店済み
+        span.badge.badge-dark
+          = @shop.reservations.enter.count
+    li.nav-item
+      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
+        | キャンセル
+        span.badge.badge-danger
+          = @shop.reservations.cancel.count
+    
+  table.table.table-hover
+    thead.thead-default
+      tr
+        th= Reservation.human_attribute_name(:reserve_on)
+        th= User.human_attribute_name(:name)
+        th= Reservation.human_attribute_name(:people_number)
+        th= Reservation.human_attribute_name(:status)
+        th
+      tbody
+        - @reservations.enter.each do |reservation|
+          tr
+            td= reservation.reserve_on.to_s(:ja)
+            td= reservation.user.name
+            td= reservation.people_number
+            td= reservation.status_i18n
+            td
+              - if reservation.yet?
+                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
+
+  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
+  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/entered.html.slim
+++ b/app/views/shops/entered.html.slim
@@ -1,62 +1,20 @@
-h1= @shop.name
-
-br
-
-strong
-  | 設定予約時間：
-  = @shop.set_expected.to_s(:ja)
+= render partial: 'management', locals: { shop: @shop }
 
 table.table.table-hover
-  tbody
+  thead.thead-default
     tr
-      th= Shop.human_attribute_name(:place)
-      td= @shop.place
+      th= Reservation.human_attribute_name(:reserve_on)
+      th= User.human_attribute_name(:name)
+      th= Reservation.human_attribute_name(:people_number)
+      th
+    tbody
+      - @reservations.enter.each do |reservation|
+        tr
+          td= reservation.reserve_on.to_s(:ja)
+          td= reservation.user.name
+          td= reservation.people_number
+          td
+            - if reservation.yet?
+              = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
 
-= form_with model: @shop, local: true do |f|
-  .form-group
-    = f.label :wait_time
-    br
-    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
-  = f.submit nil, class: 'btn btn-primary'
-
-br
-
-.col-xs-8
-  ul.nav.nav-tabs
-    li.nav-item
-      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
-        | 未入店
-        span.badge.badge-primary
-          = @shop.reservations.yet.count
-    li.nav-item
-      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
-        | 入店済み
-        span.badge.badge-dark
-          = @shop.reservations.enter.count
-    li.nav-item
-      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
-        | キャンセル
-        span.badge.badge-danger
-          = @shop.reservations.cancel.count
-    
-  table.table.table-hover
-    thead.thead-default
-      tr
-        th= Reservation.human_attribute_name(:reserve_on)
-        th= User.human_attribute_name(:name)
-        th= Reservation.human_attribute_name(:people_number)
-        th= Reservation.human_attribute_name(:status)
-        th
-      tbody
-        - @reservations.enter.each do |reservation|
-          tr
-            td= reservation.reserve_on.to_s(:ja)
-            td= reservation.user.name
-            td= reservation.people_number
-            td= reservation.status_i18n
-            td
-              - if reservation.yet?
-                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
-
-  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
-  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'
+= render partial: 'link', locals: { shop: @shop }

--- a/app/views/shops/index.html.slim
+++ b/app/views/shops/index.html.slim
@@ -1,18 +1,3 @@
-h1 Shops#index
+h1 予約できるお店一覧
 
-= link_to 'お店の追加', new_shop_path, class: 'btn btn-primary'
-
-.mb-3
-table.table.table-hover
-  thead.thead-default
-    tr
-      th= Shop.human_attribute_name(:name)
-      th= Shop.human_attribute_name(:place)
-      th= Shop.human_attribute_name(:wait_time)
-    tbody
-      - @shops.each do |shop|
-        tr
-          td= link_to shop.name, shop
-          td= shop.place
-          td
-            = shop.wait_time
+= render partial: 'table', locals: { shops: @shops }

--- a/app/views/shops/my_index.html.slim
+++ b/app/views/shops/my_index.html.slim
@@ -1,0 +1,5 @@
+h1 自分のお店一覧
+
+= link_to 'お店の追加', new_shop_path, class: 'btn btn-primary'
+
+= render partial: 'table', locals: { shops: @shops }

--- a/app/views/shops/show.html.slim
+++ b/app/views/shops/show.html.slim
@@ -21,24 +21,42 @@ table.table.table-hover
 
 br
 
-table.table.table-hover
-  thead.thead-default
-    tr
-      th= Reservation.human_attribute_name(:reserve_on)
-      th= User.human_attribute_name(:name)
-      th= Reservation.human_attribute_name(:people_number)
-      th= Reservation.human_attribute_name(:status)
-      th
-    tbody
-      - @reservations.each do |reservation|
-        tr
-          td= reservation.reserve_on.to_s(:ja)
-          td= reservation.user.name
-          td= reservation.people_number
-          td= reservation.status_i18n
-          td
-            - if reservation.yet?
-              = link_to '入店', shop_reservation_enter_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
+.col-xs-8
+  ul.nav.nav-tabs
+    li.nav-item
+      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
+        | 未入店
+        span.badge.badge-primary
+          = @shop.reservations.yet.count
+    li.nav-item
+      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
+        | 入店済み
+        span.badge.badge-dark
+          = @shop.reservations.enter.count
+    li.nav-item
+      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
+        | キャンセル
+        span.badge.badge-danger
+          = @shop.reservations.cancel.count
+    
+  table.table.table-hover
+    thead.thead-default
+      tr
+        th= Reservation.human_attribute_name(:reserve_on)
+        th= User.human_attribute_name(:name)
+        th= Reservation.human_attribute_name(:people_number)
+        th= Reservation.human_attribute_name(:status)
+        th
+      tbody
+        - @reservations.yet.each do |reservation|
+          tr
+            td= reservation.reserve_on.to_s(:ja)
+            td= reservation.user.name
+            td= reservation.people_number
+            td= reservation.status_i18n
+            td
+              - if reservation.yet?
+                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
 
-= link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
-= link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'
+  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
+  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/show.html.slim
+++ b/app/views/shops/show.html.slim
@@ -27,12 +27,18 @@ table.table.table-hover
       th= Reservation.human_attribute_name(:reserve_on)
       th= User.human_attribute_name(:name)
       th= Reservation.human_attribute_name(:people_number)
+      th= Reservation.human_attribute_name(:status)
+      th
     tbody
       - @reservations.each do |reservation|
         tr
           td= reservation.reserve_on.to_s(:ja)
           td= reservation.user.name
           td= reservation.people_number
+          td= reservation.status_i18n
+          td
+            - if reservation.yet?
+              = link_to '入店', shop_reservation_enter_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
 
 = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
 = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'

--- a/app/views/shops/show.html.slim
+++ b/app/views/shops/show.html.slim
@@ -1,62 +1,21 @@
-h1= @shop.name
-
-br
-
-strong
-  | 設定予約時間：
-  = @shop.set_expected.to_s(:ja)
-
-table.table.table-hover
-  tbody
-    tr
-      th= Shop.human_attribute_name(:place)
-      td= @shop.place
-
-= form_with model: @shop, local: true do |f|
-  .form-group
-    = f.label :wait_time
-    br
-    = f.select :wait_time, [["10",10],["20",20],["30",30],["40",40],["50",50],["60",60],["70",70],["80",80],["90",90],["100",100],["110",110],["120",120]],{} ,class: 'form-control custom-select', id: 'shop_wait_time'
-  = f.submit nil, class: 'btn btn-primary'
-
-br
-
-.col-xs-8
-  ul.nav.nav-tabs
-    li.nav-item
-      = link_to shop_path(@shop), class: "nav-link #{'active' if current_page?(shop_path(@shop))}" do
-        | 未入店
-        span.badge.badge-primary
-          = @shop.reservations.yet.count
-    li.nav-item
-      = link_to entered_shop_path(@shop), class: "nav-link #{'active' if current_page?(entered_shop_path(@shop))}" do
-        | 入店済み
-        span.badge.badge-dark
-          = @shop.reservations.enter.count
-    li.nav-item
-      = link_to canceled_shop_path(@shop), class: "nav-link #{'active' if current_page?(canceled_shop_path(@shop))}" do
-        | キャンセル
-        span.badge.badge-danger
-          = @shop.reservations.cancel.count
+= render partial: 'management', locals: { shop: @shop }
     
-  table.table.table-hover
-    thead.thead-default
-      tr
-        th= Reservation.human_attribute_name(:reserve_on)
-        th= User.human_attribute_name(:name)
-        th= Reservation.human_attribute_name(:people_number)
-        th= Reservation.human_attribute_name(:status)
-        th
-      tbody
-        - @reservations.yet.each do |reservation|
-          tr
-            td= reservation.reserve_on.to_s(:ja)
-            td= reservation.user.name
-            td= reservation.people_number
-            td= reservation.status_i18n
-            td
-              - if reservation.yet?
-                = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Reservation.human_attribute_name(:reserve_on)
+      th= User.human_attribute_name(:name)
+      th= Reservation.human_attribute_name(:people_number)
+      th
+    tbody
+      - @reservations.yet.each do |reservation|
+        tr
+          td= reservation.reserve_on.to_s(:ja)
+          td= reservation.user.name
+          td= reservation.people_number
+          td
+            - if reservation.yet?
+              = link_to '入店', enter_shop_reservation_path(@shop, reservation), method: :patch, class: 'btn btn-primary mr-3'
 
-  = link_to '詳細情報の編集', edit_shop_path(@shop), class: 'btn btn-success mr-3'
-  = link_to 'お店の削除', @shop, method: :delete, data: { confirm: "#{@shop.name}を削除します。よろしいですか。" }, class: 'btn btn-danger mr-3'
+= render partial: 'link', locals: { shop: @shop }
+    

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,7 +8,7 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
     models:
-      shop: タスク
+      shop: お店
     attributes:
       shop:
         id: ID
@@ -21,6 +21,7 @@ ja:
       reservation:
         reserve_on: 予約時間
         people_number: 人数
+        status: 状態
       user:
         name: 名前
         email: メールアドレス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,18 @@ Rails.application.routes.draw do
 
   root to: 'shops#index'
   resources :shops do
-    get :my_index, on: :collection
+    member do
+      get :canceled
+      get :entered
+    end
+    collection do
+      get :my_index
+    end
     resources :reservations, only: [:show, :new, :create, :destroy] do
-      patch :cancel
-      patch :enter
+      member do
+        patch :cancel
+        patch :enter
+      end
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     member do
       get :canceled
       get :entered
+      delete :reset
     end
     collection do
       get :my_index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get :my_index, on: :collection
     resources :reservations, only: [:show, :new, :create, :destroy] do
       patch :cancel
+      patch :enter
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   root to: 'shops#index'
   resources :shops do
+    get :my_index, on: :collection
     resources :reservations, only: [:show, :new, :create, :destroy]
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   root to: 'shops#index'
   resources :shops do
     get :my_index, on: :collection
-    resources :reservations, only: [:show, :new, :create, :destroy]
+    resources :reservations, only: [:show, :new, :create, :destroy] do
+      patch :cancel
+    end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# 追加した機能
## 全体
・店舗詳細の店側と客側での画面表示変更（客側のときは予約画面orキャンセル画面にリダイレクト）
・コントローラーとビューの共通化
## 客側機能
・予約をキャンセルした場合にも、新しく予約が行えるように実装
## 店側機能
・入店機能実装
・未入店、入店済み、キャンセルをタブで分けて表示
・予約のリセット機能追加
・待っている組と人数の表示